### PR TITLE
Replace 'transactions' with 'exchanges'

### DIFF
--- a/components/about-us-banner.vue
+++ b/components/about-us-banner.vue
@@ -15,7 +15,7 @@
         />
       </div>
       <p class="mt-6 text-lg/8 text-gray-600">
-        Mostro facilitates peer-to-peer Bitcoin transactions through the Lightning Network on Nostr, offering a private, decentralized, and censorship-resistant platform.
+        Mostro facilitates peer-to-peer Bitcoin exchanges through the Lightning Network on Nostr, offering a private, decentralized, and censorship-resistant platform.
       </p>
     </div>
     <div class="mx-auto mt-16 max-w-2xl lg:max-w-4xl">


### PR DESCRIPTION
This change is because perhaps someone unfamiliar with Mostro might think it's a wallet or something similar when reading that it facilitates Bitcoin `transactions`, even though it later mentions p2p Bitcoin exchanges

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated terminology in the About Us banner to better describe the service as "peer-to-peer Bitcoin exchanges."

<!-- end of auto-generated comment: release notes by coderabbit.ai -->