### PR TITLE
fix(typo): remove extra > in github button

### DIFF
--- a/components/contribute-banner.vue
+++ b/components/contribute-banner.vue
@@ -25,7 +25,7 @@
             <img
               class="h-5"
               src="~/assets/icons/github.svg"
-              alt="GitHub logo">
+              alt="GitHub logo"
             >
           </template>
         </base-button>


### PR DESCRIPTION
## Context
 In the [last PR](https://github.com/MostroP2P/mostro-foundation-website/pull/7) I added by mistake an extra closing tag (>) in the button that links to github. 

## What has been done
The extra closing tag was removed

Before
|Before|After|
|----|----|
|<img width="376" alt="before" src="https://github.com/user-attachments/assets/06237429-f8e4-487f-b519-2e809473b971" />|<img width="375" alt="after" src="https://github.com/user-attachments/assets/e5a9b9a7-662f-4405-8106-6268dde56ff2" />|


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Minor formatting adjustment in the `contribute-banner` component's HTML markup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->